### PR TITLE
[ADD] adding title to img-div

### DIFF
--- a/04_teste_final.html
+++ b/04_teste_final.html
@@ -107,7 +107,7 @@
 
         <hr>
 
-        <div id="pestae"></div>
+        <div id="pestae" title="Pesta the plage spirit illustration"></div>
 
         <h2>Regional Effects</h2>
         <p class="description">The region containing a pesta suffers of the creature's insidious presence, creating the following magical effects:</p>


### PR DESCRIPTION
Adicionado a tag title que funciona como titulo para imagens dentro de uma tag div caso uma imagem estivesse dentro diretamente de uma tag img poderia ser utilizado o atributo alt